### PR TITLE
Add option for migrate command

### DIFF
--- a/app/Console/Commands/Migrate.php
+++ b/app/Console/Commands/Migrate.php
@@ -5,13 +5,15 @@ use Illuminate\Contracts\Console\Kernel;
 
 class Migrate extends Command
 {
-    protected $signature = 'weblog:migrate';
+    protected $signature = 'weblog:migrate {--f|force : Force application migrations to run before weblog migrations}';
     protected $description = 'Run migrations for Laravel Weblog.';
 
     public function handle()
     {
-        $this->comment('Run application migrations, just to make sure the default migrations have been run.');
-        $this->call('migrate');
+        if($this->option('force')){
+            $this->comment('Run application migrations, just to make sure the default migrations have been run.');
+            $this->call('migrate');
+        }
         $this->comment('Run Laravel Weblog migrations.');
         $this->call('migrate', [
             '--path' => 'vendor/genealabs/laravel-weblog/database/migrations',


### PR DESCRIPTION
adding -f --force option to migrate command to force application defualt migrations to run before weblog migrations, otherwise only run weblog's migrations