### PR TITLE
Fix/change config publish path

### DIFF
--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -5,9 +5,9 @@ use GeneaLabs\LaravelWeblog\Http\Controllers\Posts;
 use GeneaLabs\LaravelWeblog\Http\Controllers\Rss;
 use GeneaLabs\LaravelWeblog\Http\Controllers\Sitemap;
 
-Route::get(config('vendor.genealabs.laravel-weblog.blog-route-name'), Posts::class.'@index');
-Route::get(config('vendor.genealabs.laravel-weblog.rss-route-name'), Rss::class.'@index');
-Route::get(config('vendor.genealabs.laravel-weblog.sitemap-route-name'), Sitemap::class.'@index');
+Route::get(config('laravel-weblog.blog-route-name'), Posts::class.'@index');
+Route::get(config('laravel-weblog.rss-route-name'), Rss::class.'@index');
+Route::get(config('laravel-weblog.sitemap-route-name'), Sitemap::class.'@index');
 Route::resource('posts', Posts::class);
 
 Route::group(['prefix' => 'genealabs/laravel-weblog'], function () {

--- a/app/Providers/LaravelWeblog.php
+++ b/app/Providers/LaravelWeblog.php
@@ -26,7 +26,7 @@ class LaravelWeblog extends AggregateServiceProvider
         ], 'assets');
 
         $this->publishes([
-            __DIR__.'/../../config/laravel-weblog.php' => config_path('vendor/genealabs/laravel-weblog.php'),
+            __DIR__.'/../../config/laravel-weblog.php' => config_path('laravel-weblog.php'),
         ], 'config');
 
         $this->publishes([
@@ -35,7 +35,7 @@ class LaravelWeblog extends AggregateServiceProvider
 
         $this->loadViewsFrom(__DIR__.'/../../resources/views', 'genealabs-laravel-weblog');
 
-        if (!config('vendor.genealabs.laravel-weblog.user-model')) {
+        if (!config('laravel-weblog.user-model')) {
             throw new Exception("You haven't specified a user model. Please add an entry for 'model' or 'providers.users.model' in /config/auth.php. Alternatively you may publish the configuration file ('php artisan weblog:publish --config') and specify your user model there.");
         }
 
@@ -47,7 +47,7 @@ class LaravelWeblog extends AggregateServiceProvider
         parent::register();
 
         AliasLoader::getInstance()->alias('sitemap', Sitemap::class);
-        $this->mergeConfigFrom(__DIR__.'/../../config/laravel-weblog.php', 'vendor.genealabs.laravel-weblog');
+        $this->mergeConfigFrom(__DIR__.'/../../config/laravel-weblog.php', 'laravel-weblog');
         $this->commands(Migrate::class);
         $this->commands(Publish::class);
     }

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -1,4 +1,4 @@
-@extends (config('vendor.genealabs.laravel-weblog.layout-view'))
+@extends (config('laravel-weblog.layout-view'))
 
 @section ('css')
     <link rel="stylesheet" href="{{ elixir('css/app.css', 'vendor/genealabs/laravel-weblog') }}">

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -1,4 +1,4 @@
-@extends (config('vendor.genealabs.laravel-weblog.layout-view'))
+@extends (config('laravel-weblog.layout-view'))
 
 @section ('css')
     <link rel="stylesheet" href="{{ elixir('css/app.css', 'vendor/genealabs/laravel-weblog') }}">

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -1,4 +1,4 @@
-@extends (config('vendor.genealabs.laravel-weblog.layout-view'))
+@extends (config('laravel-weblog.layout-view'))
 
 @section ('css')
     <link rel="stylesheet" href="{{ elixir('css/app.css', 'vendor/genealabs/laravel-weblog') }}">


### PR DESCRIPTION
Changing config publishing directory to be the standard config directory instead of using vendor sub directories. 

I believe in Laravel 5.0 default publishing directory was just standard config directory instead of using vendor directories. 